### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,11 @@ Writing modified preferences to device...
 ## Required device software version
 
 This API and tool both require that the device is running Meshtastic 0.6.0 or later.
+
+
+## Required Python modules
+
+This API and tool both require additional modules
+```
+pip install pygatt
+```


### PR DESCRIPTION
C:\Users\slavomir\workspace\meshtastic\Meshtastic-python>meshtastic --setpref wait_bluetooth_secs 28800
Traceback (most recent call last):
  File "c:\users\slavomir\appdata\local\programs\python\python38-32\lib\runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "c:\users\slavomir\appdata\local\programs\python\python38-32\lib\runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "C:\Users\slavomir\AppData\Local\Programs\Python\Python38-32\Scripts\meshtastic.exe\__main__.py", line 4, in <module>
  File "c:\users\slavomir\appdata\local\programs\python\python38-32\lib\site-packages\meshtastic\__init__.py", line 50, in <module>
    import pygatt
ModuleNotFoundError: No module named 'pygatt'