### PR TITLE
Requires was failing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     packages=["meshtastic"],
     include_package_data=True,
     install_requires=["pyserial>=3.4", "protobuf>=3.6.1",
-                      "pypubsub>=4.0.3", "dotmap>=1.3.14", "pexpect>=4.6.0", "PyQRCode>=1.2.1"
+                      "pypubsub>=4.0.3", "dotmap>=1.3.14", "pexpect>=4.6.0", "PyQRCode>=1.2.1",
                       "pygatt>=4.0.5"],
     python_requires='>=3.4',
     entry_points={


### PR DESCRIPTION
I was getting this error: 

`ERROR: Could not find a version that satisfies the requirement PyQRCode>=1.2.1pygatt>=4.0.5 (from meshtastic) (from versions: 0.10, 0.10.1, 0.11, 1.0, 1.1, 1.1.1, 1.2, 1.2.1)`