### PR TITLE
Add setURL() method to MeshInterface

### DIFF
--- a/meshtastic/__init__.py
+++ b/meshtastic/__init__.py
@@ -208,6 +208,19 @@ class MeshInterface:
         s = base64.urlsafe_b64encode(bytes).decode('ascii')
         return f"https://www.meshtastic.org/c/#{s}"
 
+    def setURL(self, url, write=True):
+        """Set mesh network URL"""
+        if self.radioConfig == None:
+            raise Exception("No RadioConfig has been read")
+
+        # URLs are of the form https://www.meshtastic.org/c/#{base64_channel_settings}
+        # Split on '/#' to find the base64 encoded channel settings
+        splitURL = url.split("/#")
+        decodedURL = base64.urlsafe_b64decode(splitURL[-1])
+        self.radioConfig.channel_settings.ParseFromString(decodedURL)
+        if write:
+            self.writeConfig()
+
     def _generatePacketId(self):
         """Get a new unique packet ID"""
         if self.currentPacketId is None:

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -176,11 +176,7 @@ def onConnected(interface):
 
             # Handle set URL
             if args.seturl:
-                # URLs are of the form https://www.meshtastic.org/c/#{base64_channel_settings}
-                # Split on '/#' to find the base64 encoded channel settings
-                splitURL = args.seturl.split("/#")
-                bytes = base64.urlsafe_b64decode(splitURL[-1])
-                interface.radioConfig.channel_settings.ParseFromString(bytes)
+                interface.setURL(args.seturl, False)
 
             print("Writing modified preferences to device")
             interface.writeConfig()


### PR DESCRIPTION
Added setURL() method so that URL's can be set from the python API.