### PR TITLE
add --version cli flag

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -11,6 +11,7 @@ import pyqrcode
 import traceback
 import codecs
 import base64
+import pkg_resources
 
 """The command line arguments"""
 args = None
@@ -348,6 +349,8 @@ def main():
                         action='store_false', help="Turns off router mode")
 
     parser.set_defaults(router=None)
+
+    parser.add_argument('--version', action='version', version=f"{pkg_resources.require('meshtastic')[0].version}")
 
     global args
     args = parser.parse_args()


### PR DESCRIPTION
Add support for interrogating the currently running version of `meshtastic` CLI:

```
meshtastic --version
1.1.21
```

Automatically uses the version string specified in setup.py according to the steps at https://stackoverflow.com/a/2073599

Closes #37 