### PR TITLE
Expose API over http server

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -390,6 +390,12 @@ def onConnected(interface):
             closeNow = False
             tunnel.Tunnel(interface, subnet=args.tunnel_net)
 
+        if args.http:
+            from . import http_server
+            # Even if others said we could close, stay open if the user asked for a http server
+            closeNow = False
+            http_server.SimpleHTTPRequestHandler(interface)
+
     except Exception as ex:
         print(f"Exception while handling connection: {ex}")
 
@@ -586,6 +592,9 @@ def initParser():
                         action='store_true', help="Deprecated, use --set is_router true instead")
     parser.add_argument('--unset-router', dest='router',
                         action='store_false', help="Deprecated, use --set is_router false instead")
+
+    parser.add_argument('--http-server',
+                        action='store_false', help="Expose API over http server")
 
     if have_tunnel:
         parser.add_argument('--tunnel',

--- a/meshtastic/http_server.py
+++ b/meshtastic/http_server.py
@@ -1,0 +1,14 @@
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
+  def do_GET(self):
+    if self.path == "/hotspot-detect.html":
+      self.send_response(200)
+      self.send_header("Content-type", "text/html")
+      self.end_headers()
+      self.wfile.write(b'Hello, world!')
+    else:
+        self.send_error(404)
+
+httpd = HTTPServer(('localhost', 8000), SimpleHTTPRequestHandler)
+httpd.serve_forever()


### PR DESCRIPTION
This is very naive implementation (first time trying Python) of how we could expose the API over an http server, in order for radios to communicate over USB with a computer in order to use the web ui.

Ideally we'd have exactly the same endpoints as the web-server that has already been implemented.