### PR TITLE
Wait indefinitely for packets when --tunnel is specified.

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -511,7 +511,7 @@ def common():
             # We assume client is fully connected now
             onConnected(client)
 
-            if args.noproto:  # loop until someone presses ctrlc
+            if args.noproto or (args.tunnel and have_tunnel):  # loop until someone presses ctrlc
                 while True:
                     time.sleep(1000)
 


### PR DESCRIPTION
Fix #96.  Make sure the race condition never happens.