### PR TITLE
Add optional channelIndex parameter to sendText convenience method

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ For the rough notes/implementation plan see [TODO](https://github.com/meshtastic
 
 This pip package will also install a "meshtastic" command line executable, which displays packets sent over the network as JSON and lets you see serial debugging information from the meshtastic devices. The source code for this tool is also a good [example](https://github.com/meshtastic/Meshtastic-python/blob/master/meshtastic/__main__.py) of a 'complete' application that uses the meshtastic python API.
 
-NOTE: This command is not run inside of python, you run it from your operating system shell prompt directly.  If when you type "meshtastic" it doesn't find the command and you are using Windows: Check that the python "scripts" directory [is in your path](https://datatofish.com/add-python-to-windows-path/).
+NOTE: This command is not run inside of python; you run it from your operating system shell prompt directly.  If when you type "meshtastic" it doesn't find the command and you are using Windows: Check that the python "scripts" directory [is in your path](https://datatofish.com/add-python-to-windows-path/).
 
 To display a (partial) list of the available commands:
 
@@ -146,7 +146,7 @@ There is a problem with Big Sur and pyserial. The workaround is to install a new
 pip3 install -U --pre pyserial
 ```
 
-Afterwards you can use the meshatstic python client again on MacOS.
+Afterwards you can use the Meshtastic python client again on MacOS.
 
 ## A note to developers of this lib
 

--- a/meshtastic/__init__.py
+++ b/meshtastic/__init__.py
@@ -246,7 +246,8 @@ class MeshInterface:
                  wantAck=False,
                  wantResponse=False,
                  hopLimit=defaultHopLimit,
-                 onResponse=None):
+                 onResponse=None,
+                 channelIndex=0):
         """Send a utf8 string to some other node, if the node has a display it will also be shown on the device.
 
         Arguments:
@@ -265,7 +266,8 @@ class MeshInterface:
                              wantAck=wantAck,
                              wantResponse=wantResponse,
                              hopLimit=hopLimit,
-                             onResponse=onResponse)
+                             onResponse=onResponse,
+                             channelIndex=channelIndex);
 
     def sendData(self, data, destinationId=BROADCAST_ADDR,
                  portNum=portnums_pb2.PortNum.PRIVATE_APP, wantAck=False,


### PR DESCRIPTION
This allows sending to arbitrary channels instead of (just) the primary channel.

Also, fixed a typo in the README.