### PR TITLE
Fixed order of have_tunnel check

### DIFF
--- a/bin/regen-protos.sh
+++ b/bin/regen-protos.sh
@@ -6,3 +6,6 @@ protoc -I=proto --python_out meshtastic `ls proto/*.proto`
 # workaround for import bug in protoc https://github.com/protocolbuffers/protobuf/issues/1491#issuecomment-690618628
 
 sed -i -E 's/^import.*_pb2/from . \0/' meshtastic/*.py
+
+# automate the current workaround (may be related to Meshtastic-protobufs issue #27 https://github.com/meshtastic/Meshtastic-protobufs/issues/27)
+sed -i "s/^None = 0/globals()['None'] = 0/" meshtastic/mesh_pb2.py

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -511,7 +511,7 @@ def common():
             # We assume client is fully connected now
             onConnected(client)
 
-            if args.noproto or (args.tunnel and have_tunnel):  # loop until someone presses ctrlc
+            if args.noproto or (have_tunnel and args.tunnel):  # loop until someone presses ctrlc
                 while True:
                     time.sleep(1000)
 


### PR DESCRIPTION
On Windows (which doesn't have tunnel support) have_tunnel will be false and args.tunnel doesn't exist. When checking to see if this command should continue running the check is evaluated left to right, meaning args.tunnel is checked first giving the error:

AttributeError: 'Namespace' object has no attribute 'tunnel'

Switching the order fixes it.