### PR TITLE
reserved word fix in regen-protos.sh

### DIFF
--- a/bin/regen-protos.sh
+++ b/bin/regen-protos.sh
@@ -6,3 +6,6 @@ protoc -I=proto --python_out meshtastic `ls proto/*.proto`
 # workaround for import bug in protoc https://github.com/protocolbuffers/protobuf/issues/1491#issuecomment-690618628
 
 sed -i -E 's/^import.*_pb2/from . \0/' meshtastic/*.py
+
+# automate the current workaround (may be related to Meshtastic-protobufs issue #27 https://github.com/meshtastic/Meshtastic-protobufs/issues/27)
+sed -i "s/^None = 0/globals()['None'] = 0/" meshtastic/mesh_pb2.py


### PR DESCRIPTION
It looks like a workaround for the use of reserved words in the protobufs is done by hand (changing None to globals()['None']). This PR adds that step to the regen-protos.sh script.

May be related to Meshtastic-protobufs issue: https://github.com/meshtastic/Meshtastic-protobufs/issues/27