### PR TITLE
Add pylint

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,83 @@
+# pylint configuration file
+#
+# Note: "pylint --generate-rcfile" is helpful to see what values to add to this file
+
+
+[MASTER]
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=mqtt_pb2.py,channel_pb2.py,environmental_measurement_pb2.py,admin_pb2.py,radioconfig_pb2.py,deviceonly_pb2.py,apponly_pb2.py,remote_hardware_pb2.py,portnums_pb2.py,mesh_pb2.py
+
+
+
+[MESSAGES CONTROL]
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+#
+disable=invalid-name,fixme,logging-fstring-interpolation,too-many-statements,too-many-branches,too-many-locals,no-member,f-string-without-interpolation,protected-access
+
+
+[BASIC]
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,j,k,ex,Run,_
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,bar,baz,toto,tutu,tata
+
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=150
+
+# Maximum number of lines in a module
+max-module-lines=1200
+
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=10
+
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,fixme,XXX,TODO
+
+
+[SIMILARITIES]
+
+# Minimum lines number of a similarity.
+min-similarity-lines=30
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=yes
+
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method.
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=20

--- a/.pylintrc
+++ b/.pylintrc
@@ -23,7 +23,7 @@ ignore-patterns=mqtt_pb2.py,channel_pb2.py,environmental_measurement_pb2.py,admi
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
 #
-disable=invalid-name,fixme,logging-fstring-interpolation,too-many-statements,too-many-branches,too-many-locals,no-member,f-string-without-interpolation,protected-access
+disable=invalid-name,fixme,logging-fstring-interpolation,too-many-statements,too-many-branches,too-many-locals,no-member,f-string-without-interpolation,protected-access,no-self-use,pointless-string-statement,too-few-public-methods,consider-using-f-string
 
 
 [BASIC]
@@ -77,7 +77,7 @@ ignore-imports=yes
 [DESIGN]
 
 # Maximum number of arguments for function / method.
-max-args=5
+max-args=10
 
 # Maximum number of attributes for a class (see R0902).
 max-attributes=20

--- a/README.md
+++ b/README.md
@@ -156,5 +156,10 @@ If you need to build a new release you'll need:
 
 ```
 apt install pandoc
-sudo pip3 install markdown pdoc3 webencodings pyparsing twine autopep8
+sudo pip3 install markdown pdoc3 webencodings pyparsing twine autopep8 pylint
+```
+
+To lint, run:
+```
+pylint meshtastic
 ```

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -1,21 +1,18 @@
 #!python3
+""" Main Meshtastic
+"""
 
 import argparse
 import platform
 import logging
 import sys
-import codecs
 import time
-import base64
 import os
-from . import SerialInterface, TCPInterface, BLEInterface, test, remote_hardware
 from pubsub import pub
-from . import mesh_pb2, portnums_pb2, channel_pb2
-from .util import stripnl
-import google.protobuf.json_format
 import pyqrcode
-import traceback
 import pkg_resources
+from . import SerialInterface, TCPInterface, BLEInterface, test, remote_hardware
+from . import portnums_pb2, channel_pb2
 
 """We only import the tunnel code if we are on a platform that can run it"""
 have_tunnel = platform.system() == 'Linux'
@@ -65,11 +62,12 @@ falseTerms = {"f", "false", "no"}
 
 
 def genPSK256():
+    """Generate a random preshared key"""
     return os.urandom(32)
 
 
 def fromPSK(valstr):
-    """A special version of fromStr that assumes the user is trying to set a PSK.  
+    """A special version of fromStr that assumes the user is trying to set a PSK.
     In that case we also allow "none", "default" or "random" (to have python generate one), or simpleN
     """
     if valstr == "random":
@@ -93,9 +91,9 @@ def fromStr(valstr):
     Args:
         valstr (string): A user provided string
     """
-    if(len(valstr) == 0):  # Treat an emptystring as an empty bytes
+    if len(valstr) == 0:  # Treat an emptystring as an empty bytes
         val = bytes()
-    elif(valstr.startswith('0x')):
+    elif valstr.startswith('0x'):
         # if needed convert to string with asBytes.decode('utf-8')
         val = bytes.fromhex(valstr[2:])
     elif valstr in trueTerms:
@@ -134,7 +132,7 @@ def getPref(attributes, name):
     try:
         try:
             val = getattr(attributes, name)
-        except TypeError as ex:
+        except TypeError:
             # The getter didn't like our arg type guess try again as a string
             val = getattr(attributes, name)
 
@@ -175,7 +173,7 @@ def setPref(attributes, name, valStr):
     try:
         try:
             setattr(attributes, name, val)
-        except TypeError as ex:
+        except TypeError:
             # The setter didn't like our arg type guess try again as a string
             setattr(attributes, name, valStr)
 
@@ -479,7 +477,7 @@ def common():
             else:
                 args.seriallog = "none"  # assume no debug output in this case
 
-        if args.deprecated != None:
+        if args.deprecated is not None:
             logging.error(
                 'This option has been deprecated, see help below for the correct replacement...')
             parser.print_help(sys.stderr)
@@ -520,6 +518,7 @@ def common():
 
 
 def initParser():
+    """ Initialize the command line argument parsing."""
     global parser, args
 
     parser.add_argument(

--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -28,10 +28,10 @@ type of packet, you should subscribe to the full topic name.  If you want to see
 - meshtastic.receive.data.portnum(packet) (where portnum is an integer or well known PortNum enum)
 - meshtastic.node.updated(node = NodeInfo) - published when a node in the DB changes (appears, location changed, username changed, etc...)
 
-We receive position, user, or data packets from the mesh.  You probably only care about meshtastic.receive.data.  The first argument for 
-that publish will be the packet.  Text or binary data packets (from sendData or sendText) will both arrive this way.  If you print packet 
-you'll see the fields in the dictionary.  decoded.data.payload will contain the raw bytes that were sent.  If the packet was sent with 
-sendText, decoded.data.text will **also** be populated with the decoded string.  For ASCII these two strings will be the same, but for 
+We receive position, user, or data packets from the mesh.  You probably only care about meshtastic.receive.data.  The first argument for
+that publish will be the packet.  Text or binary data packets (from sendData or sendText) will both arrive this way.  If you print packet
+you'll see the fields in the dictionary.  decoded.data.payload will contain the raw bytes that were sent.  If the packet was sent with
+sendText, decoded.data.text will **also** be populated with the decoded string.  For ASCII these two strings will be the same, but for
 unicode scripts they can be different.
 
 # Example Usage
@@ -55,24 +55,12 @@ interface = meshtastic.SerialInterface()
 
 """
 
-import pygatt
-import google.protobuf.json_format
-import serial
-import threading
 import logging
-import sys
-import random
-import traceback
-import time
 import base64
-import platform
-import socket
-from . import mesh_pb2, portnums_pb2, apponly_pb2, admin_pb2, environmental_measurement_pb2, remote_hardware_pb2, channel_pb2, radioconfig_pb2, util
-from .util import fixme, catchAndIgnore, stripnl, DeferredExecution, Timeout
-from pubsub import pub
-from dotmap import DotMap
 from typing import *
 from google.protobuf.json_format import MessageToJson
+from . import portnums_pb2, apponly_pb2, admin_pb2, channel_pb2
+from .util import stripnl, Timeout
 
 
 
@@ -142,7 +130,7 @@ class Node:
 
     def writeConfig(self):
         """Write the current (edited) radioConfig to the device"""
-        if self.radioConfig == None:
+        if self.radioConfig is None:
             raise Exception("No RadioConfig has been read")
 
         p = admin_pb2.AdminMessage()
@@ -250,7 +238,7 @@ class Node:
 
     def setURL(self, url):
         """Set mesh network URL"""
-        if self.radioConfig == None:
+        if self.radioConfig is None:
             raise Exception("No RadioConfig has been read")
 
         # URLs are of the form https://www.meshtastic.org/d/#{base64_channel_set}
@@ -400,5 +388,3 @@ class Node:
                                    wantResponse=wantResponse,
                                    onResponse=onResponse,
                                    channelIndex=adminIndex)
-
-

--- a/meshtastic/remote_hardware.py
+++ b/meshtastic/remote_hardware.py
@@ -1,6 +1,6 @@
 
-from . import portnums_pb2, remote_hardware_pb2
 from pubsub import pub
+from . import portnums_pb2, remote_hardware_pb2
 
 
 def onGPIOreceive(packet, interface):
@@ -13,7 +13,7 @@ def onGPIOreceive(packet, interface):
 
 class RemoteHardwareClient:
     """
-    This is the client code to control/monitor simple hardware built into the 
+    This is the client code to control/monitor simple hardware built into the
     meshtastic devices.  It is intended to be both a useful API/service and example
     code for how you can connect to your own custom meshtastic services
     """

--- a/meshtastic/test.py
+++ b/meshtastic/test.py
@@ -1,11 +1,13 @@
+""" Testing
+"""
 import logging
-from . import util
-from . import SerialInterface, TCPInterface, BROADCAST_NUM
-from pubsub import pub
 import time
 import sys
-import threading, traceback
+import traceback
 from dotmap import DotMap
+from pubsub import pub
+from . import util
+from . import SerialInterface, TCPInterface, BROADCAST_NUM
 
 """The interfaces we are using for our tests"""
 interfaces = None
@@ -31,7 +33,7 @@ def onReceive(packet, interface):
 
         if p.decoded.portnum == "TEXT_MESSAGE_APP":
             # We only care a about clear text packets
-            if receivedPackets != None:
+            if receivedPackets is not None:
                 receivedPackets.append(p)
 
 
@@ -75,18 +77,19 @@ def testSend(fromInterface, toInterface, isBroadcast=False, asBinary=False, want
     else:
         fromInterface.sendData((f"Binary {testNumber}").encode(
             "utf-8"), toNode, wantAck=wantAck)
-    for sec in range(60):  # max of 60 secs before we timeout
+    for _ in range(60):  # max of 60 secs before we timeout
         time.sleep(1)
-        if (len(receivedPackets) >= 1):
+        if  len(receivedPackets) >= 1:
             return True
     return False  # Failed to send
 
 
 def runTests(numTests=50, wantAck=False, maxFailures=0):
+    """Run the tests."""
     logging.info(f"Running {numTests} tests with wantAck={wantAck}")
     numFail = 0
     numSuccess = 0
-    for i in range(numTests):
+    for _ in range(numTests):
         global testNumber
         testNumber = testNumber + 1
         isBroadcast = True
@@ -116,6 +119,7 @@ def runTests(numTests=50, wantAck=False, maxFailures=0):
 
 
 def testThread(numTests=50):
+    """Test thread"""
     logging.info("Found devices, starting tests...")
     runTests(numTests, wantAck=True)
     # Allow a few dropped packets
@@ -128,6 +132,7 @@ def onConnection(topic=pub.AUTO_TOPIC):
 
 
 def openDebugLog(portName):
+    """Open the debug log file"""
     debugname = "log" + portName.replace("/", "_")
     logging.info(f"Writing serial debugging to {debugname}")
     return open(debugname, 'w+', buffering=1)
@@ -141,7 +146,7 @@ def testAll():
         Exception: If not enough devices are found
     """
     ports = util.findPorts()
-    if (len(ports) < 2):
+    if len(ports) < 2:
         raise Exception("Must have at least two devices connected to USB")
 
     pub.subscribe(onConnection, "meshtastic.connection")

--- a/meshtastic/tunnel.py
+++ b/meshtastic/tunnel.py
@@ -1,4 +1,5 @@
-# code for IP tunnel over a mesh
+""" Code for IP tunnel over a mesh
+
 # Note python-pytuntap was too buggy
 # using pip3 install pytap2
 # make sure to "sudo setcap cap_net_admin+eip /usr/bin/python3.8" so python can access tun device without being root
@@ -12,11 +13,12 @@
 # ping -i 30 -W 30 10.115.64.152
 
 # FIXME: use a more optimal MTU
+"""
 
-from . import portnums_pb2
-from pubsub import pub
 import logging
 import threading
+from pubsub import pub
+from . import portnums_pb2
 
 # A new non standard log level that is lower level than DEBUG
 LOG_TRACE = 5

--- a/meshtastic/util.py
+++ b/meshtastic/util.py
@@ -1,9 +1,13 @@
-
-from collections import defaultdict
-import serial, traceback
-import serial.tools.list_ports
+""" Utility functions.
+"""
+import traceback
 from queue import Queue
-import threading, sys, time, logging
+import sys
+import time
+import logging
+import threading
+import serial
+import serial.tools.list_ports
 
 """Some devices such as a seger jlink we never want to accidentally open"""
 blacklistVids = dict.fromkeys([0x1366])
@@ -16,6 +20,7 @@ def stripnl(s):
 
 
 def fixme(message):
+    """raise an exception for things that needs to be fixed"""
     raise Exception(f"FIXME: {message}")
 
 
@@ -34,7 +39,7 @@ def findPorts():
         list -- a list of device paths
     """
     l = list(map(lambda port: port.device,
-                 filter(lambda port: port.vid != None and port.vid not in blacklistVids,
+                 filter(lambda port: port.vid is not None and port.vid not in blacklistVids,
                         serial.tools.list_ports.comports())))
     l.sort()
     return l
@@ -48,6 +53,7 @@ class dotdict(dict):
 
 
 class Timeout:
+    """Timeout class"""
     def __init__(self, maxSecs=20):
         self.expireTime = 0
         self.sleepInterval = 0.1
@@ -77,6 +83,7 @@ class DeferredExecution():
         self.thread.start()
 
     def queueWork(self, runnable):
+        """ Queue up the work"""
         self.queue.put(runnable)
 
     def _run(self):


### PR DESCRIPTION
Addresses part of #125 

This is a good first pass to get the initial configuration to a decent level. 

I would recommend some devs with a bit more experience to 

Here's an example run:

```
% pylint meshtastic
************* Module meshtastic
meshtastic/__init__.py:536:0: C0301: Line too long (168/150) (line-too-long)
meshtastic/__init__.py:540:0: C0301: Line too long (162/150) (line-too-long)
meshtastic/__init__.py:163:44: W0621: Redefining name 'traceback' from outer scope (line 67) (redefined-outer-name)
meshtastic/__init__.py:171:23: W0613: Unused argument 'file' (unused-argument)
meshtastic/__init__.py:183:42: W0613: Unused argument 'file' (unused-argument)
meshtastic/__init__.py:240:8: R1705: Unnecessary "else" after "return" (no-else-return)
meshtastic/__init__.py:367:8: R1720: Unnecessary "elif" after "raise" (no-else-raise)
meshtastic/__init__.py:444:8: R1720: Unnecessary "else" after "raise" (no-else-raise)
meshtastic/__init__.py:503:12: W1505: Using deprecated method warn() (deprecated-method)
meshtastic/__init__.py:551:12: W0702: No exception type(s) specified (bare-except)
meshtastic/__init__.py:600:8: W0702: No exception type(s) specified (bare-except)
meshtastic/__init__.py:609:8: R1705: Unnecessary "else" after "return" (no-else-return)
meshtastic/__init__.py:634:11: C0113: Consider changing "not 'from' in asDict" to "'from' not in asDict" (unneeded-not)
meshtastic/__init__.py:639:11: C0113: Consider changing "not 'to' in asDict" to "'to' not in asDict" (unneeded-not)
meshtastic/__init__.py:645:15: W0703: Catching too general exception Exception (broad-except)
meshtastic/__init__.py:646:12: W1505: Using deprecated method warn() (deprecated-method)
meshtastic/__init__.py:649:15: W0703: Catching too general exception Exception (broad-except)
meshtastic/__init__.py:650:12: W1505: Using deprecated method warn() (deprecated-method)
meshtastic/__init__.py:487:8: W0201: Attribute 'nodesByNum' defined outside __init__ (attribute-defined-outside-init)
meshtastic/__init__.py:490:8: W0201: Attribute 'configId' defined outside __init__ (attribute-defined-outside-init)
meshtastic/__init__.py:732:24: W0613: Unused argument 'handle' (unused-argument)
meshtastic/__init__.py:824:25: W0622: Redefining built-in 'len' (redefined-builtin)
meshtastic/__init__.py:902:15: W0703: Catching too general exception Exception (broad-except)
meshtastic/__init__.py:866:31: C0121: Comparison 'self.debugOut != None' should be 'self.debugOut is not None' (singleton-comparison)
meshtastic/__init__.py:869:32: W0702: No exception type(s) specified (bare-except)
meshtastic/__init__.py:886:35: W0703: Catching too general exception Exception (broad-except)
meshtastic/__init__.py:896:16: W1505: Using deprecated method warn() (deprecated-method)
meshtastic/__init__.py:814:15: E0203: Access to member 'stream' before its definition line 816 (access-member-before-definition)
meshtastic/__init__.py:815:12: E0203: Access to member 'stream' before its definition line 816 (access-member-before-definition)
meshtastic/__init__.py:816:12: W0201: Attribute 'stream' defined outside __init__ (attribute-defined-outside-init)
meshtastic/__init__.py:924:12: R1720: Unnecessary "elif" after "raise" (no-else-raise)
meshtastic/__init__.py:961:8: W0702: No exception type(s) specified (bare-except)
meshtastic/__init__.py:1008:12: W0702: No exception type(s) specified (bare-except)
meshtastic/__init__.py:1016:25: W0622: Redefining built-in 'len' (redefined-builtin)
meshtastic/__init__.py:1032:11: W0703: Catching too general exception Exception (broad-except)
************* Module meshtastic.remote_hardware
meshtastic/remote_hardware.py:31:0: C0301: Line too long (155/150) (line-too-long)
meshtastic/remote_hardware.py:40:83: W1401: Anomalous backslash in string: '\!'. String constant might be missing an r prefix. (anomalous-backslash-in-string)
meshtastic/remote_hardware.py:1:0: C0114: Missing module docstring (missing-module-docstring)
meshtastic/remote_hardware.py:6:26: W0613: Unused argument 'interface' (unused-argument)
************* Module meshtastic.util
meshtastic/util.py:31:11: W0703: Catching too general exception BaseException (broad-except)
meshtastic/util.py:94:12: W0702: No exception type(s) specified (bare-except)
************* Module meshtastic.test
meshtastic/test.py:62:4: W0603: Using the global statement (global-statement)
meshtastic/test.py:73:4: W0603: Using the global statement (global-statement)
meshtastic/test.py:93:8: W0603: Using the global statement (global-statement)
meshtastic/test.py:138:11: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
meshtastic/test.py:154:4: W0603: Using the global statement (global-statement)
meshtastic/test.py:174:30: W0125: Using a conditional statement with a constant value (using-constant-test)
meshtastic/test.py:183:4: W0702: No exception type(s) specified (bare-except)
************* Module meshtastic.tunnel
meshtastic/tunnel.py:61:28: W0613: Unused argument 'interface' (unused-argument)
meshtastic/tunnel.py:85:8: W0603: Using the global statement (global-statement)
meshtastic/tunnel.py:101:8: C0415: Import outside toplevel (pytap2.TapDevice) (import-outside-toplevel)
meshtastic/tunnel.py:110:4: C0116: Missing function or method docstring (missing-function-docstring)
meshtastic/tunnel.py:208:4: C0116: Missing function or method docstring (missing-function-docstring)
************* Module meshtastic.node
meshtastic/node.py:60:0: W0401: Wildcard import typing (wildcard-import)
meshtastic/node.py:69:4: R1705: Unnecessary "elif" after "return" (no-else-return)
meshtastic/node.py:73:8: R1705: Unnecessary "elif" after "return" (no-else-return)
meshtastic/node.py:191:8: R1705: Unnecessary "else" after "return" (no-else-return)
meshtastic/node.py:235:8: W0622: Redefining built-in 'bytes' (redefined-builtin)
meshtastic/node.py:123:8: W0201: Attribute 'partialChannels' defined outside __init__ (attribute-defined-outside-init)
meshtastic/node.py:60:0: W0614: Unused import(s) collections, contextlib, functools, operator, stdlib_re, sys, types, Any, NoReturn, ClassVar, Final, Union, Optional, Literal, ForwardRef, TypeVar, Generic, EXCLUDED_ATTRIBUTES, Protocol, Annotated, runtime_checkable, cast, get_type_hints, get_origin, get_args, no_type_check, no_type_check_decorator, overload, final, T, KT, VT, T_co, V_co, VT_co, T_contra, CT_co, AnyStr, Hashable, Awaitable, Coroutine, AsyncIterable, AsyncIterator, Iterable, Iterator, Reversible, Sized, Container, Collection, Callable, AbstractSet, MutableSet, Mapping, MutableMapping, Sequence, MutableSequence, ByteString, Tuple, List, Deque, Set, FrozenSet, MappingView, KeysView, ItemsView, ValuesView, ContextManager, AsyncContextManager, Dict, DefaultDict, OrderedDict, Counter, ChainMap, Generator, AsyncGenerator, Type, SupportsInt, SupportsFloat, SupportsComplex, SupportsBytes, SupportsIndex, SupportsAbs, SupportsRound, NamedTupleMeta, NamedTuple, TypedDict, NewType, Text, TYPE_CHECKING, IO, BinaryIO, TextIO, io, Pattern, Match, re, abstractmethod, ABCMeta, WrapperDescriptorType, MethodWrapperType, MethodDescriptorType and GenericAlias from wildcard import of typing (unused-wildcard-import)
************* Module meshtastic.__main__
meshtastic/__main__.py:51:11: W0703: Catching too general exception Exception (broad-except)
meshtastic/__main__.py:55:17: W0613: Unused argument 'interface' (unused-argument)
meshtastic/__main__.py:73:4: R1705: Unnecessary "elif" after "return" (no-else-return)
meshtastic/__main__.py:141:11: W0703: Catching too general exception Exception (broad-except)
meshtastic/__main__.py:160:20: C0123: Use isinstance() rather than type() for a typecheck. (unidiomatic-typecheck)
meshtastic/__main__.py:182:11: W0703: Catching too general exception Exception (broad-except)
meshtastic/__main__.py:209:12: W0621: Redefining name 'time' from outer scope (line 9) (redefined-outer-name)
meshtastic/__main__.py:432:11: W0703: Catching too general exception Exception (broad-except)
meshtastic/__main__.py:193:8: W0602: Using global for 'args' but no assignment is done (global-variable-not-assigned)
meshtastic/__main__.py:198:12: W0603: Using the global statement (global-statement)
meshtastic/__main__.py:423:12: C0415: Import outside toplevel (.tunnel) (import-outside-toplevel)
meshtastic/__main__.py:455:4: W0602: Using global for 'args' but no assignment is done (global-variable-not-assigned)
meshtastic/__main__.py:463:12: W0603: Using the global statement (global-statement)
meshtastic/__main__.py:496:26: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
meshtastic/__main__.py:496:26: R1732: Consider using 'with' for resource-allocating operations (consider-using-with)
meshtastic/__main__.py:522:4: W0602: Using global for 'parser' but no assignment is done (global-variable-not-assigned)
meshtastic/__main__.py:667:4: W0602: Using global for 'args' but no assignment is done (global-variable-not-assigned)

------------------------------------------------------------------
Your code has been rated at 9.40/10 (previous run: 9.40/10, +0.00)
```

