### PR TITLE
Added very basic implementation of configure command for provisioning / setting preferences via yaml

### DIFF
--- a/example_config.yaml
+++ b/example_config.yaml
@@ -1,0 +1,15 @@
+owner: Bob TBeam
+
+channel_url: https://www.meshtastic.org/d/#CgUYAyIBAQ
+
+location:
+  lat: 35.88888
+  lon: -93.88888
+  alt: 304
+
+user_prefs:
+  region: 1
+  is_always_powered: true
+  send_owner_interval: 2
+  screen_on_secs: 31536000
+  wait_bluetooth_secs: 31536000

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,3 +54,4 @@ urllib3==1.26.7
 webencodings==0.5.1
 wrapt==1.13.3
 zipp==3.6.0
+pyyaml==5.3.0


### PR DESCRIPTION
I placed an example yaml configuration in the root of the repo. The command syntax is:
`meshtastic --configure ./my_config.yaml`