### PR TITLE
Ham, not HAM

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Meshtastic is designed to be used without a radio operator license.  If you do h
 ```
 meshtastic --port /dev/ttyUSB1 --set-ham KI1345
 Connected to radio
-Setting HAM ID to KI1345 and turning off encryption
+Setting Ham ID to KI1345 and turning off encryption
 Writing modified channels to device
 ```
 

--- a/docs/meshtastic/tests/test_main.html
+++ b/docs/meshtastic/tests/test_main.html
@@ -395,7 +395,7 @@ def test_main_set_ham_to_KI123(capsys, reset_globals):
         main()
         out, err = capsys.readouterr()
         assert re.search(r&#39;Connected to radio&#39;, out, re.MULTILINE)
-        assert re.search(r&#39;Setting HAM ID to KI123&#39;, out, re.MULTILINE)
+        assert re.search(r&#39;Setting Ham ID to KI123&#39;, out, re.MULTILINE)
         assert re.search(r&#39;inside mocked setOwner&#39;, out, re.MULTILINE)
         assert re.search(r&#39;inside mocked turnOffEncryptionOnPrimaryChannel&#39;, out, re.MULTILINE)
         assert err == &#39;&#39;
@@ -2437,7 +2437,7 @@ def test_main_set_ham_to_KI123(capsys, reset_globals):
         main()
         out, err = capsys.readouterr()
         assert re.search(r&#39;Connected to radio&#39;, out, re.MULTILINE)
-        assert re.search(r&#39;Setting HAM ID to KI123&#39;, out, re.MULTILINE)
+        assert re.search(r&#39;Setting Ham ID to KI123&#39;, out, re.MULTILINE)
         assert re.search(r&#39;inside mocked setOwner&#39;, out, re.MULTILINE)
         assert re.search(r&#39;inside mocked turnOffEncryptionOnPrimaryChannel&#39;, out, re.MULTILINE)
         assert err == &#39;&#39;

--- a/docs/meshtastic/tests/test_smoke1.html
+++ b/docs/meshtastic/tests/test_smoke1.html
@@ -691,7 +691,7 @@ def test_smoke1_set_ham():
        Note: Do a factory reset after this setting so it is very short-lived.
     &#34;&#34;&#34;
     return_value, out = subprocess.getstatusoutput(&#39;meshtastic --set-ham KI1234&#39;)
-    assert re.search(r&#39;Setting HAM ID&#39;, out, re.MULTILINE)
+    assert re.search(r&#39;Setting Ham ID&#39;, out, re.MULTILINE)
     assert return_value == 0
     # pause for the radio
     time.sleep(PAUSE_AFTER_REBOOT)
@@ -1510,7 +1510,7 @@ def test_smoke1_set_ham():
        Note: Do a factory reset after this setting so it is very short-lived.
     &#34;&#34;&#34;
     return_value, out = subprocess.getstatusoutput(&#39;meshtastic --set-ham KI1234&#39;)
-    assert re.search(r&#39;Setting HAM ID&#39;, out, re.MULTILINE)
+    assert re.search(r&#39;Setting Ham ID&#39;, out, re.MULTILINE)
     assert return_value == 0
     # pause for the radio
     time.sleep(PAUSE_AFTER_REBOOT)

--- a/docs/python-cmd-guide.md
+++ b/docs/python-cmd-guide.md
@@ -196,7 +196,7 @@ meshtastic --dest \!28979058 --set-owner "MeshyJohn"
 
 ### --set-ham SET_HAM
 
-Set licensed HAM ID and turn off encryption.
+Set licensed Ham ID and turn off encryption.
 
 **Usage**
 

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -228,7 +228,7 @@ def onConnected(interface):
 
         if args.set_ham:
             closeNow = True
-            print(f"Setting HAM ID to {args.set_ham} and turning off encryption")
+            print(f"Setting Ham ID to {args.set_ham} and turning off encryption")
             getNode().setOwner(args.set_ham, is_licensed=True)
             # Must turn off encryption on primary channel
             getNode().turnOffEncryptionOnPrimaryChannel()
@@ -738,7 +738,7 @@ def initParser():
         "--set-team", help="Set team affiliation (an invalid team will list valid values)", action="store")
 
     parser.add_argument(
-        "--set-ham", help="Set licensed HAM ID and turn off encryption", action="store")
+        "--set-ham", help="Set licensed Ham ID and turn off encryption", action="store")
 
     parser.add_argument(
         "--dest", help="The destination node id for any sent commands, if not set '^all' or '^local' is assumed as appropriate", default=None)

--- a/meshtastic/tests/test_main.py
+++ b/meshtastic/tests/test_main.py
@@ -370,7 +370,7 @@ def test_main_set_ham_to_KI123(capsys, reset_globals):
         main()
         out, err = capsys.readouterr()
         assert re.search(r'Connected to radio', out, re.MULTILINE)
-        assert re.search(r'Setting HAM ID to KI123', out, re.MULTILINE)
+        assert re.search(r'Setting Ham ID to KI123', out, re.MULTILINE)
         assert re.search(r'inside mocked setOwner', out, re.MULTILINE)
         assert re.search(r'inside mocked turnOffEncryptionOnPrimaryChannel', out, re.MULTILINE)
         assert err == ''

--- a/meshtastic/tests/test_smoke1.py
+++ b/meshtastic/tests/test_smoke1.py
@@ -662,7 +662,7 @@ def test_smoke1_set_ham():
        Note: Do a factory reset after this setting so it is very short-lived.
     """
     return_value, out = subprocess.getstatusoutput('meshtastic --set-ham KI1234')
-    assert re.search(r'Setting HAM ID', out, re.MULTILINE)
+    assert re.search(r'Setting Ham ID', out, re.MULTILINE)
     assert return_value == 0
     # pause for the radio
     time.sleep(PAUSE_AFTER_REBOOT)


### PR DESCRIPTION
Originally discovered in https://github.com/meshtastic/Meshtastic/pull/160/commits/1ffa55d39a8270686c8ba087634d31826c0f4a33

https://www.kb6nu.com/ham-ham-radio-ham-radio-amateur-radio/#:~:text=Of%20course%20either%20term%20may,be%20avoided%20at%20all%20costs.