### PR TITLE
if mac address is in nodes, format it like a valid mac address

### DIFF
--- a/meshtastic/mesh_interface.py
+++ b/meshtastic/mesh_interface.py
@@ -18,7 +18,7 @@ from google.protobuf.json_format import MessageToJson
 
 import meshtastic.node
 from . import portnums_pb2, mesh_pb2
-from .util import stripnl, Timeout, our_exit, remove_keys_from_dict
+from .util import stripnl, Timeout, our_exit, remove_keys_from_dict, convert_mac_addr
 from .__init__ import LOCAL_ADDR, BROADCAST_NUM, BROADCAST_ADDR, ResponseHandler, publishingThread, OUR_APP_VERSION, protocols
 
 class MeshInterface:
@@ -87,6 +87,14 @@ class MeshInterface:
                 # when the TBeam is first booted, it sometimes shows the 'raw' data
                 # so, we will just remove any raw keys
                 n2 = remove_keys_from_dict('raw', n)
+
+                # if we have 'macaddr', re-format it
+                if 'macaddr' in n2['user']:
+                    val = n2['user']['macaddr']
+                    # decode the base64 value
+                    addr = convert_mac_addr(val)
+                    n2['user']['macaddr'] = addr
+
                 nodes = nodes + f"  {stripnl(n2)}"
         infos = owner + myinfo + mesh + nodes
         print(infos)

--- a/meshtastic/tests/test_util.py
+++ b/meshtastic/tests/test_util.py
@@ -10,7 +10,7 @@ from meshtastic.util import (fixme, stripnl, pskToString, our_exit,
                              support_info, genPSK256, fromStr, fromPSK,
                              quoteBooleans, catchAndIgnore,
                              remove_keys_from_dict, Timeout, hexstr,
-                             ipstr, readnet_u16, findPorts)
+                             ipstr, readnet_u16, findPorts, convert_mac_addr)
 
 
 @pytest.mark.unit
@@ -225,3 +225,10 @@ def test_readnet_u16():
 def test_findPorts_when_none_found(patch_comports):
     """Test findPorts()"""
     assert not findPorts()
+
+
+@pytest.mark.unit
+def test_convert_mac_addr():
+    """Test convert_mac_addr()"""
+    assert convert_mac_addr('/c0gFyhb') == 'fd:cd:20:17:28:5b'
+    assert convert_mac_addr('') == ''

--- a/meshtastic/util.py
+++ b/meshtastic/util.py
@@ -4,6 +4,7 @@ import traceback
 from queue import Queue
 import os
 import sys
+import base64
 import time
 import platform
 import logging
@@ -224,3 +225,12 @@ def ipstr(barray):
 def readnet_u16(p, offset):
     """Read big endian u16 (network byte order)"""
     return p[offset] * 256 + p[offset + 1]
+
+
+def convert_mac_addr(val):
+    """Convert the base 64 encoded value to a mac address
+       val - base64 encoded value (ex: '/c0gFyhb'))
+       returns: a string formatted like a mac address (ex: 'fd:cd:20:17:28:5b')
+    """
+    val_as_bytes = base64.b64decode(val)
+    return hexstr(val_as_bytes)


### PR DESCRIPTION
Before:
```
Nodes in mesh:  {'num': 538388571, 'user': {'id': '!2017285b', 'longName': 'Unknown 285b', 'shortName': '?5B', 'macaddr': '/c0gFyhb', 'hwModel': 'RAK4631'}, 'position': {'batteryLevel': 100}, 'lastHeard': 1641006636}
```

After:
```
Nodes in mesh:  {'num': 538388571, 'user': {'id': '!2017285b', 'longName': 'Unknown 285b', 'shortName': '?5B', 'macaddr': 'fd:cd:20:17:28:5b', 'hwModel': 'RAK4631'}, 'position': {'batteryLevel': 95}, 'lastHeard': 1641009077}
```