### PR TITLE
if we have a duplicate serial port use the appropriate one

### DIFF
--- a/meshtastic/serial_interface.py
+++ b/meshtastic/serial_interface.py
@@ -30,9 +30,13 @@ class SerialInterface(StreamInterface):
             if len(ports) == 0:
                 meshtastic.util.our_exit("Warning: No Meshtastic devices detected.")
             elif len(ports) > 1:
-                message = "Warning: Multiple serial ports were detected so one serial port must be specified with the '--port'.\n"
-                message += f"  Ports detected:{ports}"
-                meshtastic.util.our_exit(message)
+                tmp_ports = meshtastic.util.eliminate_duplicate_port(ports)
+                if len(tmp_ports) != 1:
+                    message = "Warning: Multiple serial ports were detected so one serial port must be specified with the '--port'.\n"
+                    message += f"  Ports detected:{ports}"
+                    meshtastic.util.our_exit(message)
+                else:
+                    devPath = tmp_ports[0]
             else:
                 devPath = ports[0]
 

--- a/meshtastic/tests/test_util.py
+++ b/meshtastic/tests/test_util.py
@@ -11,7 +11,7 @@ from meshtastic.util import (fixme, stripnl, pskToString, our_exit,
                              quoteBooleans, catchAndIgnore,
                              remove_keys_from_dict, Timeout, hexstr,
                              ipstr, readnet_u16, findPorts, convert_mac_addr,
-                             snake_to_camel, camel_to_snake)
+                             snake_to_camel, camel_to_snake, eliminate_duplicate_port)
 
 
 @pytest.mark.unit
@@ -272,3 +272,15 @@ def test_camel_to_snake():
     assert camel_to_snake('Foo') == 'foo'
     assert camel_to_snake('fooBar') == 'foo_bar'
     assert camel_to_snake('fooBarBaz') == 'foo_bar_baz'
+
+
+@pytest.mark.unit
+def test_eliminate_duplicate_port():
+    """Test eliminate_duplicate_port()"""
+    assert not eliminate_duplicate_port([])
+    assert eliminate_duplicate_port(['/dev/fake']) == ['/dev/fake']
+    assert eliminate_duplicate_port(['/dev/fake', '/dev/fake1']) == ['/dev/fake', '/dev/fake1']
+    assert eliminate_duplicate_port(['/dev/fake', '/dev/fake1', '/dev/fake2']) == ['/dev/fake', '/dev/fake1', '/dev/fake2']
+    assert eliminate_duplicate_port(['/dev/cu.usbserial-1430', '/dev/cu.wchusbserial1430']) == ['/dev/cu.wchusbserial1430']
+    assert eliminate_duplicate_port(['/dev/cu.SLAB_USBtoUART', '/dev/cu.usbserial-0001']) == ['/dev/cu.usbserial-0001']
+    assert eliminate_duplicate_port(['/dev/cu.usbmodem11301', '/dev/cu.wchusbserial11301']) == ['/dev/cu.wchusbserial11301']

--- a/meshtastic/util.py
+++ b/meshtastic/util.py
@@ -381,3 +381,37 @@ def detect_windows_needs_driver(sd, print_reason=False):
                 if print_reason:
                     print(sp_output)
     return need_to_install_driver
+
+
+def eliminate_duplicate_port(ports):
+    """Sometimes we detect 2 serial ports, but we really only need to use one of the ports.
+
+       ports is a list of ports
+       return a list with a single port to use, if it meets the duplicate port conditions
+
+        examples:
+            Ports: ['/dev/cu.usbserial-1430', '/dev/cu.wchusbserial1430'] => ['/dev/cu.wchusbserial1430']
+            Ports: ['/dev/cu.usbmodem11301', '/dev/cu.wchusbserial11301'] => ['/dev/cu.wchusbserial11301']
+            Ports: ['/dev/cu.SLAB_USBtoUART', '/dev/cu.usbserial-0001'] => ['/dev/cu.usbserial-0001']
+    """
+    new_ports = []
+    if len(ports) != 2:
+        new_ports = ports
+    else:
+        if 'usbserial' in ports[0] and 'wchusbserial' in ports[1]:
+            first = ports[0].replace("usbserial-", "")
+            second = ports[1].replace("wchusbserial", "")
+            print(f'first:{first} second:{second}')
+            if first == second:
+                new_ports.append(ports[1])
+        elif 'usbmodem' in ports[0] and 'wchusbserial' in ports[1]:
+            first = ports[0].replace("usbmodem", "")
+            second = ports[1].replace("wchusbserial", "")
+            print(f'first:{first} second:{second}')
+            if first == second:
+                new_ports.append(ports[1])
+        elif 'SLAB_USBtoUART' in ports[0] and 'usbserial' in ports[1]:
+            new_ports.append(ports[1])
+        else:
+            new_ports = ports
+    return new_ports

--- a/meshtastic/util.py
+++ b/meshtastic/util.py
@@ -401,13 +401,11 @@ def eliminate_duplicate_port(ports):
         if 'usbserial' in ports[0] and 'wchusbserial' in ports[1]:
             first = ports[0].replace("usbserial-", "")
             second = ports[1].replace("wchusbserial", "")
-            print(f'first:{first} second:{second}')
             if first == second:
                 new_ports.append(ports[1])
         elif 'usbmodem' in ports[0] and 'wchusbserial' in ports[1]:
             first = ports[0].replace("usbmodem", "")
             second = ports[1].replace("wchusbserial", "")
-            print(f'first:{first} second:{second}')
             if first == second:
                 new_ports.append(ports[1])
         elif 'SLAB_USBtoUART' in ports[0] and 'usbserial' in ports[1]:


### PR DESCRIPTION
Fix #264 