### PR TITLE
work on some canned message fixes

### DIFF
--- a/exampleConfig.yaml
+++ b/exampleConfig.yaml
@@ -12,6 +12,6 @@ location:
 userPrefs:
   region: 1
   isAlwaysPowered: 'true'
-  sendOwnerInterval: 2
   screenOnSecs: 31536000
   waitBluetoothSecs: 31536000
+canned: "What am I doing?|I'm fine|Don't follow me|I'm out|I'm back|Need helping hand|Help me with saw|I need an alpinist|I need ambulance|Keep Calm|On my way|Need 5 mins|I will be late|I'm already waiting|I couldn't join|We have company|Beer is cold|Roger"

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -12,7 +12,7 @@ location:
 user_prefs:
   region: 1
   is_always_powered: 'true'
-  send_owner_interval: 2
   screen_on_secs: 31536000
   wait_bluetooth_secs: 31536000
   location_share: 'LocEnabled'
+canned: "What am I doing?|I'm fine|Don't follow me|I'm out|I'm back|Need helping hand|Help me with saw|I need an alpinist|I need ambulance|Keep Calm|On my way|Need 5 mins|I will be late|I'm already waiting|I couldn't join|We have company|Beer is cold|Roger"

--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -215,7 +215,6 @@ def onConnected(interface):
             print(f"Setting device owner short to {args.set_owner_short}")
             interface.getNode(args.dest).setOwner(long_name=None, short_name=args.set_owner_short)
 
-        # TODO: add to export-config and configure
         if args.set_canned_message:
             closeNow = True
             print(f"Setting canned plugin message to {args.set_canned_message}")
@@ -407,6 +406,11 @@ def onConnected(interface):
                     for pref in configuration['userPrefs']:
                         setPref(prefs, pref, str(configuration['userPrefs'][pref]))
                     print("Writing modified preferences to device")
+                    interface.getNode(args.dest).writeConfig()
+
+                if 'canned' in configuration:
+                    print(f'Setting canned: {configuration["canned"]}')
+                    interface.getNode(args.dest).set_canned_message(configuration['canned'])
                     interface.getNode(args.dest).writeConfig()
 
         if args.export_config:
@@ -614,6 +618,7 @@ def export_config(interface):
     channel_url = interface.localNode.getURL()
     myinfo = interface.getMyNodeInfo()
     pos = myinfo.get('position')
+    canned = interface.localNode.get_canned_message()
     lat = None
     lon = None
     alt = None
@@ -654,6 +659,8 @@ def export_config(interface):
                 config += f"  {meshtastic.util.snake_to_camel(meshtastic.util.quoteBooleans(pref))}\n"
             else:
                 config += f"  {meshtastic.util.quoteBooleans(pref)}\n"
+    if canned != "":
+        config += f"canned: {canned}\n"
     print(config)
     return config
 

--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -383,10 +383,6 @@ class Node:
             while self.gotResponse is False:
                 time.sleep(0.1)
 
-            # TODO: This feels wrong to have a sleep here. Is there a way to ensure that
-            # all requests are complete? Perhaps change to a while loop any parts are None... maybe?
-            time.sleep(3)
-
             logging.debug(f'self.cannedPluginMessagePart1:{self.cannedPluginMessagePart1}')
             logging.debug(f'self.cannedPluginMessagePart2:{self.cannedPluginMessagePart2}')
             logging.debug(f'self.cannedPluginMessagePart3:{self.cannedPluginMessagePart3}')
@@ -418,12 +414,14 @@ class Node:
         for i in range(0, len(message), chunks_size):
             chunks.append(message[i: i + chunks_size])
 
+        # need to ensure there are 4 parts so we clear any old chunks
+        for i in range(len(chunks), 4):
+            chunks.append("")
+
         # for each chunk, send a message to set the values
-        #for i in range(0, len(chunks)):
         for i, chunk in enumerate(chunks):
             p = admin_pb2.AdminMessage()
 
-            # TODO: should be a way to improve this
             if i == 0:
                 p.set_canned_message_module_part1 = chunk
             elif i == 1:
@@ -433,8 +431,9 @@ class Node:
             elif i == 3:
                 p.set_canned_message_module_part4 = chunk
 
-            logging.debug(f"Setting canned message '{chunk}' part {i+1}")
             self._sendAdmin(p)
+            # TODO: really should check if the device got the request
+            time.sleep(1.0)
 
     def exitSimulator(self):
         """Tell a simulator node to exit (this message


### PR DESCRIPTION
Struggling to consistently `set` the canned messages. I think the -device needs to have a response on the `set` requests.