### PR TITLE
Fix changing modem_preset from CLI shortcuts

### DIFF
--- a/meshtastic/__main__.py
+++ b/meshtastic/__main__.py
@@ -456,12 +456,10 @@ def onConnected(interface):
 
         def setSimpleConfig(modem_preset):
             """Set one of the simple modem_config"""
-            # Completely new radio settings
-            chs = config_pb2.Config.LoRaConfig()
-            chs.modem_preset = modem_preset
+            # Overwrite modem_preset
             prefs = interface.getNode(args.dest).localConfig
-            prefs.lora.CopyFrom(chs)
-            interface.getNode(args.dest).writeConfig()
+            prefs.lora.modem_preset = modem_preset
+            interface.getNode(args.dest).writeConfig('lora')
 
         # handle the simple radio set commands
         if args.ch_vlongslow:


### PR DESCRIPTION
Previously the channel shortcuts (e.g. --ch-shortfast) would overrwrite
the entire lora config, this meant you lost other configured things such
as region. This patch changes that so that just modem_preset is
overwritten, and also fixes the call to write config that was missing
an argument.