### PR TITLE
Add KnownProtocol for Simulator_App

### DIFF
--- a/meshtastic/__init__.py
+++ b/meshtastic/__init__.py
@@ -182,5 +182,6 @@ protocols = {
     portnums_pb2.PortNum.ADMIN_APP: KnownProtocol("admin", admin_pb2.AdminMessage),
     portnums_pb2.PortNum.ROUTING_APP: KnownProtocol("routing", mesh_pb2.Routing),
     portnums_pb2.PortNum.TELEMETRY_APP: KnownProtocol("telemetry", telemetry_pb2.Telemetry),
-    portnums_pb2.PortNum.REMOTE_HARDWARE_APP: KnownProtocol("remotehw", remote_hardware_pb2.HardwareMessage)
+    portnums_pb2.PortNum.REMOTE_HARDWARE_APP: KnownProtocol("remotehw", remote_hardware_pb2.HardwareMessage), 
+    portnums_pb2.PortNum.SIMULATOR_APP: KnownProtocol("simulator", mesh_pb2.Compressed)
 }


### PR DESCRIPTION
I would like to add a KnownProtocol for simulating multiple instances of the Linux native application. See also my [PR in Meshtastic-device.](https://github.com/meshtastic/Meshtastic-device/pull/1737) 