### PR TITLE
Catch RoutingApp response for Admin packet

### DIFF
--- a/meshtastic/node.py
+++ b/meshtastic/node.py
@@ -516,6 +516,17 @@ class Node:
     def onRequestGetMetadata(self, p):
         """Handle the response packet for requesting device metadata getMetadata()"""
         logging.debug(f'onRequestGetMetadata() p:{p}')
+
+        if p["decoded"]["portnum"] == portnums_pb2.PortNum.Name(portnums_pb2.PortNum.ROUTING_APP):
+            print('No admin, error reason: ', p["decoded"]["routing"]["errorReason"])
+            if p["decoded"]["routing"]["errorReason"] != "NONE":
+                logging.warning(f'Metadata request failed, error reason: {p["decoded"]["routing"]["errorReason"]}')
+                self._timeout.expireTime = time.time() # Do not wait any longer
+                return # Don't try to parse this routing message
+            logging.debug(f"Retrying metadata request.")
+            self.getMetadata()
+            return 
+            
         c = p["decoded"]["admin"]["raw"].get_device_metadata_response
         self._timeout.reset()  # We made foreward progress
         logging.debug(f"Received metadata {stripnl(c)}")


### PR DESCRIPTION
When you send an Admin packet to a remote node, it might happen that instead of an AdminApp packet, you get a RoutingApp packet in response due to e.g. a 'NOT_AUTHORIZED' or 'MAX_RETRANSMISSIONS' error. Previously it would then throw a KeyError: 'admin' (as [this issue](https://github.com/meshtastic/Meshtastic-device/issues/1757) also mentions). This will catch the actual routing error and warns the user or retries if the error is 'NONE'. 